### PR TITLE
revert to nodejs 15.9

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:15.9.0-alpine3.12
 ARG JD_BASE_URL=https://ghproxy.com/https://github.com/wuzhi05/jd-base
 ARG JD_BASE_BRANCH=main
 ARG JD_SCRIPTS_URL=https://ghproxy.com/https://github.com/wuzhi05/MyActions


### PR DESCRIPTION
New 16.0 nodejs would cause the container always failed with "bash git_pull no such file or directory error".
I am not sure what cause it. 
I forked your repo and revert it to workaround it.